### PR TITLE
Use & as there is already query parameter before and Config out Zoom level

### DIFF
--- a/classes/EOLManager.php
+++ b/classes/EOLManager.php
@@ -79,7 +79,7 @@ class EOLManager {
 	private function queryEolIdentifier($tid, $sciName, $makePrimaryLink){
 		$retStatus = false;
 		$url = 'http://eol.org/api/search/1.0.json?q='.urlencode($sciName);
-		if(isset($GLOBALS['EOL_KEY']) && $GLOBALS['EOL_KEY']) $url .= '?key='.$GLOBALS['EOL_KEY'];
+		if(isset($GLOBALS['EOL_KEY']) && $GLOBALS['EOL_KEY']) $url .= '&key='.$GLOBALS['EOL_KEY'];
 		if($fh = fopen($url, 'r')){
 			echo '<li>Reading identifier for '.$sciName.' (tid: <a href="../index.php?taxon='.$tid.'" target="_blank">'.$tid.'</a>)... ';
 			$content = '';

--- a/collections/map/mapinterface.php
+++ b/collections/map/mapinterface.php
@@ -340,7 +340,7 @@ elseif($stArr || ($mapType && $mapType == 'occquery') || $clid){
             }
 
             var dmOptions = {
-                zoom: 6,
+                zoom: <?php echo $GOOGLE_MAP_ZOOM; ?>,
                 center: pos,
                 mapTypeId: google.maps.MapTypeId.TERRAIN,
                 mapTypeControl: true,

--- a/config/symbini_template.php
+++ b/config/symbini_template.php
@@ -55,6 +55,7 @@ $FP_ENABLED = 0;					//Enable Filtered-Push modules
 
 //Misc variables
 $GOOGLE_MAP_KEY = '';				//Needed for Google Map; get from Google 
+$GOOGLE_MAP_ZOOM = 6;                           // Set the map zoom level
 $MAPPING_BOUNDARIES = '';			//Project bounding box; default map centering; (e.g. 42.3;-100.5;18.0;-127)
 $SPATIAL_INITIAL_CENTER = '';	    //Initial map center for Spatial Module. Default: '[-110.90713, 32.21976]'
 $SPATIAL_INITIAL_ZOOM = '';			//Initial zoom for Spatial Module. Default: 7


### PR DESCRIPTION
The use of `?` causes the EOL mapper to fail as the query parameter is messed. Basically what we will be having is something like

```
http://eol.org/api/search/1.0.json?q=<some params>?key=<some key>
```
and not 
```
http://eol.org/api/search/1.0.json?q=<some params>&key=<some key>
```

This one line will fix the above issue for EOL mapper to work correctly.

Currenty the Google map zoom is fixed at level 6, Well for bigger countries it works amazingly. But for smaller countries like Bhutan, it is not really contextual, as it shows non relevant markers. So extracting out the Zoom level in config file, so that every one can set the level accordingly.
