### PR TITLE
Update to place the GenBankGen plugin in the Occurrence Editor -> Linked Resources tab

### DIFF
--- a/collections/editor/includes/resourcetab.php
+++ b/collections/editor/includes/resourcetab.php
@@ -338,3 +338,19 @@ $dupClusterArr = $dupManager->getClusterArr($occid);
 		</div>
 	</fieldset>
 </div>
+<div id="geneticdiv"  style="width:795px;">
+        <fieldset>
+                <legend><b>GenBank Submission</b></legend>
+		<?php
+		    if(isset($GENBANK_SUB_TOOL_PATH)){
+		        $lib_path = $GENBANK_SUB_TOOL_PATH."/genbankgen/plugin.php";
+		        include_once $lib_path;
+		        if(class_exists('\GenBankGen\Plugin')) {
+			    $defaults->SYMB_UID = $SYMB_UID;
+			    $p = new \GenBankGen\Plugin($defaults);
+			    echo $p->embed();
+		        }
+		    }
+		?>
+        </fieldset>
+</div>

--- a/collections/individual/index.php
+++ b/collections/individual/index.php
@@ -296,7 +296,7 @@ header("Content-Type: text/html; charset=".$CHARSET);
 						<li><a href="#maptab"><span>Map</span></a></li>
 						<?php
 					}
-					if($genticArr || isset($GENBANK_SUB_TOOL_PATH)) echo '<li><a href="#genetictab"><span>Genetic Data</span></a></li>';
+					if($genticArr)) echo '<li><a href="#genetictab"><span>Genetic Data</span></a></li>';
 					if($dupClusterArr){
 						?>
 						<li><a href="#dupestab"><span>Duplicates</span></a></li>
@@ -913,7 +913,7 @@ header("Content-Type: text/html; charset=".$CHARSET);
 						</div>
 					<?php
 				}
-				if($genticArr || isset($GENBANK_SUB_TOOL_PATH)){
+				if($genticArr){
 					?>
 					<div id="genetictab">
 						<?php
@@ -931,14 +931,6 @@ header("Content-Type: text/html; charset=".$CHARSET);
 							</div>
 							<?php
 						}
-                        if(isset($GENBANK_SUB_TOOL_PATH)){
-                            include_once $GENBANK_SUB_TOOL_PATH."/genbankgen/plugin.php";
-                            if(class_exists('\GenBankGen\Plugin')) {
-                                $defaults->SYMB_UID = $SYMB_UID;
-                                $p = new \GenBankGen\Plugin($defaults);
-                                echo $p->embed();
-                            }
-                        }
 						?>
 					</div>
 					<?php


### PR DESCRIPTION
The GenBankGen plugin should only display for portal users with the appropriate permissions.
Placing this in the Occurrence Editor solves this issue.

I have also removed previous references in the Record Information -> Genetic Data tab.